### PR TITLE
Check current task status if leased

### DIFF
--- a/pkg/tasks/task_service.go
+++ b/pkg/tasks/task_service.go
@@ -166,7 +166,7 @@ func (s *TaskServiceServer) Logs(in *proto.LogTaskRequest, stream proto.TaskServ
 }
 
 func (s *TaskServiceServer) patchTaskStatus(ctx context.Context, tasks ...*proto.Task) error {
-	// The storage returns running/queueuing as queueing.
+	// The storage returns running/queueing as queueing.
 	// Needs to query the task tracker for the real status.
 	for _, task := range tasks {
 		if task.Status == proto.TaskStatus_TASK_STATUS_QUEUEING {

--- a/tests/cases/batch.go
+++ b/tests/cases/batch.go
@@ -223,6 +223,7 @@ EOF
 chmod +x cancel_script.sh
 job_id=$(vbatch ./cancel_script.sh testfile_cancel)
 
+while [ velda task get $job_id | grep -q TASK_STATUS_RUNNING ]; do sleep 0.1; done
 while [ ! -f testfile_cancel.STARTED ]; do sleep 0.2; done
 velda task cancel $job_id
 while ! (velda task get $job_id | grep -q TASK_STATUS_FAIL); do sleep 0.1; done


### PR DESCRIPTION
When a task is actively leased by the server, it will update the task status in result so it's not always queueing.