### PR TITLE
Improve error handling

### DIFF
--- a/pkg/db/sqlite/db.go
+++ b/pkg/db/sqlite/db.go
@@ -278,6 +278,9 @@ func rowToTask(row interface {
 
 	err := row.Scan(dest...)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
 		return nil, err
 	}
 
@@ -463,12 +466,6 @@ func (s *SqliteDatabase) GetTask(ctx context.Context, taskId string) (*proto.Tas
 SELECT `+taskColumns(option)+`
 FROM tasks
 WHERE parent_id = ? AND task_id = ?`, parentId, taskId)
-	if row.Err() != nil {
-		if errors.Is(row.Err(), sql.ErrNoRows) {
-			return nil, db.ErrNotFound
-		}
-		return nil, row.Err()
-	}
 	return rowToTask(row, option)
 }
 


### PR DESCRIPTION
1. Hide wrapped errors when converting status error message to external.
2. fix gettask returning internal error if task not found.