### PR TITLE
Revise Isaac Sim documentation for Isaac Lab

### DIFF
--- a/docs/examples/isaac-sim.md
+++ b/docs/examples/isaac-sim.md
@@ -1,8 +1,13 @@
-## Run NVIDIA Isaac Sim on Velda Cloud
+## Run NVIDIA Isaac Lab on Velda Cloud
 
+### About Isaac Sim
 NVIDIA Isaac Sim is a robotics simulation platform used to build and test physical AI workflows in realistic 3D environments. It is widely used for robotics development, synthetic data generation, and digital twin simulation.
-
 For full product details, see the official NVIDIA page: [NVIDIA Isaac Sim](https://developer.nvidia.com/isaac/sim).
+
+### About Isaac Lab
+Isaac Lab is a GPU-accelerated, open-source framework designed to unify and simplify robotics research workflows, such as reinforcement learning, imitation learning, and motion planning. 
+
+Learn more at [Github](https://github.com/isaac-sim/IsaacLab)
 
 With Velda, you can launch Isaac Sim on a serverless GPU in about a minute, and access directly through your browser.
 
@@ -10,31 +15,36 @@ With Velda, you can launch Isaac Sim on a serverless GPU in about a minute, and 
 
 ## Quick Start
 
-### 1. Clone the Isaac Sim template
-Find [`NVIDIA Isaac SIM`](https://velda.cloud/image/nvidia-isaac-sim-5-1) in the image catalog. Create a new instance from the template.
+This is a ready-to-run Velda environment to run Isaac sim. All dependencies are installed, including GUI, Isaac Sim,
+Isaac Lab.
 
-### 2. Start the simulator
+## Run Reinforcement learning in headless mode
+Headless mode disables rendering for faster speed.
 
-```bash
-# Install Velda CLI
-curl https://velda.cloud/install.sh | bash
+To run RL in headless mode, choose the pool with desired GPU (e.g. l40s-1-16d for L40s and 16 cpu cores), and prefix
+the command with `vrun -P [pool]`. Example:
 
-# Start the simulator
-velda run -s isaac -P l40s-1-16d -i <instance-name> sh start.sh
+```
+vrun -P l40s-1-16ds ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
 ```
 
-This starts Isaac Sim on an NVIDIA L40S GPU pool in the cloud.
-It will include Xorg server, XFCE window manager, VNC for remote desktop, noVNC/websockify for web access, and Isaac Sim.
+## Run Reinforcement learning with direct rendering, and view from browser
+You can also start an X-window server to inspect the simulation with GUI.
 
-Please note GPU rendering is not supported on Ampere / Hopper / Blackwell.
+Velda provides builtin VNC forwarding over HTTP, so you can view the result directly from browser.
 
-### 3. Open Isaac Sim in your browser
+To run a command with rendering enabled, add `-s isaac` to the vrun command, and prefix the command with `./runx`.
+Example:
 
-When the command starts, it prints a URL in the terminal. Open that URL to access the simulator directly in your browser.
+```
+vrun -P l40s-1-16ds -s isaac  ./runx  ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0
+```
 
-No desktop app install is needed.
+This will print out an URL(e.g. https://6080-isaac-123456781234.ne.velda.cloud/vnc.html) where you can view the
+GUI, and start the simulation/Reinforcement learning.
 
 ## Learn more
 
 - [Isaac Sim document](https://docs.isaacsim.omniverse.nvidia.com/5.1.0/index.html)
+- [Isaac Lab repo](https://github.com/isaac-sim/IsaacLab)
 - [Source code](https://github.com/velda-io/examples/blob/main/setup_xorg.sh) for setting up Xorg with NVIDIA rendering and remote VDI

--- a/docs/examples/isaac-sim.md
+++ b/docs/examples/isaac-sim.md
@@ -7,7 +7,7 @@ For full product details, see the official NVIDIA page: [NVIDIA Isaac Sim](https
 ### About Isaac Lab
 Isaac Lab is a GPU-accelerated, open-source framework designed to unify and simplify robotics research workflows, such as reinforcement learning, imitation learning, and motion planning. 
 
-Learn more at [Github](https://github.com/isaac-sim/IsaacLab)
+Learn more at [GitHub](https://github.com/isaac-sim/IsaacLab).
 
 With Velda, you can launch Isaac Sim on a serverless GPU in about a minute, and access directly through your browser.
 
@@ -15,8 +15,7 @@ With Velda, you can launch Isaac Sim on a serverless GPU in about a minute, and 
 
 ## Quick Start
 
-This is a ready-to-run Velda environment to run Isaac sim. All dependencies are installed, including GUI, Isaac Sim,
-Isaac Lab.
+This is a ready-to-run Velda environment for Isaac Sim and Isaac Lab. All dependencies are installed, including the GUI.
 
 ## Run Reinforcement learning in headless mode
 Headless mode disables rendering for faster speed.
@@ -25,26 +24,26 @@ To run RL in headless mode, choose the pool with desired GPU (e.g. l40s-1-16d fo
 the command with `vrun -P [pool]`. Example:
 
 ```
-vrun -P l40s-1-16ds ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
+vrun -P l40s-1-16d ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
 ```
 
 ## Run Reinforcement learning with direct rendering, and view from browser
 You can also start an X-window server to inspect the simulation with GUI.
 
-Velda provides builtin VNC forwarding over HTTP, so you can view the result directly from browser.
+Velda provides built-in VNC forwarding over HTTP, so you can view the result directly in the browser.
 
 To run a command with rendering enabled, add `-s isaac` to the vrun command, and prefix the command with `./runx`.
 Example:
 
-```
-vrun -P l40s-1-16ds -s isaac  ./runx  ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0
+```bash
+vrun -P l40s-1-16d -s isaac ./runx ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0
 ```
 
-This will print out an URL(e.g. https://6080-isaac-123456781234.ne.velda.cloud/vnc.html) where you can view the
-GUI, and start the simulation/Reinforcement learning.
+This will print a URL (e.g., https://6080-isaac-123456781234.ne.velda.cloud/vnc.html) where you can view the
+GUI and start the simulation/reinforcement learning.
 
 ## Learn more
 
-- [Isaac Sim document](https://docs.isaacsim.omniverse.nvidia.com/5.1.0/index.html)
+- [Isaac Sim documentation](https://docs.isaacsim.omniverse.nvidia.com/5.1.0/index.html)
 - [Isaac Lab repo](https://github.com/isaac-sim/IsaacLab)
 - [Source code](https://github.com/velda-io/examples/blob/main/setup_xorg.sh) for setting up Xorg with NVIDIA rendering and remote VDI


### PR DESCRIPTION
Updated documentation to reflect the rebranding from Isaac Sim to Isaac Lab, added new sections about Isaac Lab, and clarified instructions for running reinforcement learning in both headless and GUI modes.