### PR TITLE
Directly load some config items from secret manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.0
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.243.0
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0
 	github.com/aws/smithy-go v1.22.5

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 h1:6+lZi2J
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0/go.mod h1:eb3gfbVIxIoGgJsi9pGne19dhCBpK6opTYpQqAmdy44=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.3 h1:ieRzyHXypu5ByllM7Sp4hC5f/1Fy5wqxqY0yB85hC7s=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.3/go.mod h1:O5ROz8jHiOAKAwx179v+7sHMhfobFVi6nZt8DEyiYoM=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.0 h1:BRCDd+oBBOk/5VzR/rVk3Azy8o5oCCr8urNJQs191mE=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.0/go.mod h1:yGhDiLKguA3iFJYxbrQkQiNzuy+ddxesSZYWVeeEH5Q=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0 h1:1T8wFNEtOP4lgLC7v8Fzgbb4kFrMmnscG7kOqkbA26c=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0/go.mod h1:CDVmu8K5JKdgdJakdZ9gC3K6OJ/+izv/kUncFeGRIj4=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.0 h1:Mc/MKBf2m4VynyJkABoVEN+QzkfLqGj0aiJuEe7cMeM=
@@ -213,7 +215,6 @@ github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/s2a-go v0.1.8 h1:zZDs9gcbt9ZPLV0ndSyQk6Kacx2g/X+SKYovpnz3SMM=
 github.com/google/s2a-go v0.1.8/go.mod h1:6iNWHTpQ+nfNRN5E00MSdfDwVesa8hhS32PhPO8deJA=
-github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -322,7 +323,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=

--- a/pkg/clientlib/broker_client.go
+++ b/pkg/clientlib/broker_client.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"velda.io/velda/pkg/proto"
+	"velda.io/velda/pkg/utils"
 )
 
 const (
@@ -111,7 +112,17 @@ func GetApiConnection() (*grpc.ClientConn, error) {
 					connErr = errors.New("both broker mTLS client cert and key must be set")
 					return
 				}
-				clientCert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+				clientCertBytes, err := utils.LoadFileOrSecret(context.Background(), clientCertPath)
+				if err != nil {
+					connErr = fmt.Errorf("failed to load broker mTLS client cert: %w", err)
+					return
+				}
+				clientKeyBytes, err := utils.LoadFileOrSecret(context.Background(), clientKeyPath)
+				if err != nil {
+					connErr = fmt.Errorf("failed to load broker mTLS client key: %w", err)
+					return
+				}
+				clientCert, err := tls.X509KeyPair(clientCertBytes, clientKeyBytes)
 				if err != nil {
 					connErr = fmt.Errorf("failed to load broker mTLS client cert/key: %w", err)
 					return

--- a/pkg/utils/file_source.go
+++ b/pkg/utils/file_source.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Velda Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+const (
+	awsSecretScheme      = "awssecret"
+	awsCurrentVersionTag = "AWSCURRENT"
+)
+
+type awsSecretRef struct {
+	region  string
+	name    string
+	version string
+}
+
+// LoadFileOrSecret loads content from a local file path or an awssecret URI.
+// Supported secret format: awssecret://region/name/version, where version is optional.
+func LoadFileOrSecret(ctx context.Context, source string) ([]byte, error) {
+	if strings.HasPrefix(source, awsSecretScheme+"://") {
+		return loadAWSSecret(ctx, source)
+	}
+	return os.ReadFile(source)
+}
+
+func parseAWSSecretURI(secretURI string) (*awsSecretRef, error) {
+	parsed, err := url.Parse(secretURI)
+	if err != nil {
+		return nil, fmt.Errorf("invalid awssecret URI %q: %w", secretURI, err)
+	}
+	if parsed.Scheme != awsSecretScheme {
+		return nil, fmt.Errorf("unsupported secret scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("awssecret URI %q must include region", secretURI)
+	}
+
+	rawPath := strings.TrimPrefix(parsed.EscapedPath(), "/")
+	if rawPath == "" {
+		return nil, fmt.Errorf("awssecret URI %q must include secret name", secretURI)
+	}
+
+	parts := strings.Split(rawPath, "/")
+	decodedParts := make([]string, 0, len(parts))
+	for i, part := range parts {
+		if part == "" && i != len(parts)-1 {
+			return nil, fmt.Errorf("awssecret URI %q contains empty path segment", secretURI)
+		}
+		decodedPart, err := url.PathUnescape(part)
+		if err != nil {
+			return nil, fmt.Errorf("awssecret URI %q has invalid escaped path segment: %w", secretURI, err)
+		}
+		decodedParts = append(decodedParts, decodedPart)
+	}
+
+	ref := &awsSecretRef{region: parsed.Host}
+	if len(decodedParts) == 1 {
+		ref.name = decodedParts[0]
+		ref.version = awsCurrentVersionTag
+	} else {
+		ref.version = decodedParts[len(decodedParts)-1]
+		ref.name = strings.Join(decodedParts[:len(decodedParts)-1], "/")
+	}
+
+	if ref.name == "" {
+		return nil, fmt.Errorf("awssecret URI %q must include secret name", secretURI)
+	}
+	if ref.version == "" {
+		ref.version = awsCurrentVersionTag
+	}
+	return ref, nil
+}
+
+func loadAWSSecret(ctx context.Context, secretURI string) ([]byte, error) {
+	ref, err := parseAWSSecretURI(secretURI)
+	if err != nil {
+		return nil, err
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(ref.region))
+	if err != nil {
+		return nil, fmt.Errorf("failed loading AWS config for region %q: %w", ref.region, err)
+	}
+
+	client := secretsmanager.NewFromConfig(awsCfg)
+	input := &secretsmanager.GetSecretValueInput{SecretId: aws.String(ref.name)}
+	if strings.EqualFold(ref.version, "current") || ref.version == awsCurrentVersionTag {
+		input.VersionStage = aws.String(awsCurrentVersionTag)
+	} else {
+		input.VersionId = aws.String(ref.version)
+	}
+
+	output, err := client.GetSecretValue(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching secret %q in region %q: %w", ref.name, ref.region, err)
+	}
+
+	if output.SecretString != nil {
+		return []byte(*output.SecretString), nil
+	}
+	if output.SecretBinary != nil {
+		return output.SecretBinary, nil
+	}
+	return nil, fmt.Errorf("secret %q has no string or binary payload", ref.name)
+}

--- a/pkg/utils/file_source_test.go
+++ b/pkg/utils/file_source_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Velda Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseAWSSecretURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantRegion  string
+		wantSecret  string
+		wantVersion string
+		expectErr   bool
+	}{
+		{
+			name:        "version omitted uses current",
+			input:       "awssecret://us-west-2/my-secret",
+			wantRegion:  "us-west-2",
+			wantSecret:  "my-secret",
+			wantVersion: awsCurrentVersionTag,
+		},
+		{
+			name:        "explicit version",
+			input:       "awssecret://us-east-1/my-secret/v1",
+			wantRegion:  "us-east-1",
+			wantSecret:  "my-secret",
+			wantVersion: "v1",
+		},
+		{
+			name:        "long-name",
+			input:       "awssecret://us-east-1/my/long/secret/name/v2",
+			wantRegion:  "us-east-1",
+			wantSecret:  "my/long/secret/name",
+			wantVersion: "v2",
+		},
+		{
+			name:        "encoded-name",
+			input:       "awssecret://us-east-1/my%2Flong%2Fsecret%2Fname/v2",
+			wantRegion:  "us-east-1",
+			wantSecret:  "my/long/secret/name",
+			wantVersion: "v2",
+		},
+		{
+			name:        "long-name-without-version",
+			input:       "awssecret://us-east-1/my/long/secret/name/",
+			wantRegion:  "us-east-1",
+			wantSecret:  "my/long/secret/name",
+			wantVersion: awsCurrentVersionTag,
+		},
+		{
+			name:      "missing region",
+			input:     "awssecret:///my-secret/v1",
+			expectErr: true,
+		},
+		{
+			name:      "missing secret name",
+			input:     "awssecret://us-east-1",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := parseAWSSecretURI(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAWSSecretURI() error = %v", err)
+			}
+			if ref.region != tt.wantRegion {
+				t.Fatalf("region = %q, want %q", ref.region, tt.wantRegion)
+			}
+			if ref.name != tt.wantSecret {
+				t.Fatalf("secret = %q, want %q", ref.name, tt.wantSecret)
+			}
+			if ref.version != tt.wantVersion {
+				t.Fatalf("version = %q, want %q", ref.version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestLoadFileOrSecretLocalFile(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "cert.pem")
+	want := []byte("local file content")
+	if err := os.WriteFile(path, want, 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	got, err := LoadFileOrSecret(context.Background(), path)
+	if err != nil {
+		t.Fatalf("LoadFileOrSecret() error = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("content mismatch: got %q, want %q", string(got), string(want))
+	}
+}


### PR DESCRIPTION
This avoid the dependencies on loading secrets with cloud-init and dependency on awscli on agent.